### PR TITLE
FIX - Corregir formato dateTime en XML para SigningTime en facturas DIAN

### DIFF
--- a/src/XAdES/SignAttachedDocument.php
+++ b/src/XAdES/SignAttachedDocument.php
@@ -217,7 +217,7 @@ class SignAttachedDocument extends Sign
         $this->signedSignatureProperties = $this->domDocument->createElement('xades:SignedSignatureProperties');
         $this->signedProperties->appendChild($this->signedSignatureProperties);
 
-        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now()->format('Y-m-d\TH:i:s.vT:00'));
+        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now('America/Bogota')->format('Y-m-d\TH:i:s.vP'));
         $this->signedSignatureProperties->appendChild($this->signingTime);
 
         $this->signingCertificate = $this->domDocument->createElement('xades:SigningCertificate');

--- a/src/XAdES/SignDocumentSupport.php
+++ b/src/XAdES/SignDocumentSupport.php
@@ -235,7 +235,7 @@ class SignDocumentSupport extends Sign
         $this->signedSignatureProperties = $this->domDocument->createElement('xades:SignedSignatureProperties');
         $this->signedProperties->appendChild($this->signedSignatureProperties);
 
-        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now()->format('Y-m-d\TH:i:s.vT:00'));
+        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now('America/Bogota')->format('Y-m-d\TH:i:s.vP'));
         $this->signedSignatureProperties->appendChild($this->signingTime);
 
         $this->signingCertificate = $this->domDocument->createElement('xades:SigningCertificate');

--- a/src/XAdES/SignInvoice.php
+++ b/src/XAdES/SignInvoice.php
@@ -223,7 +223,7 @@ class SignInvoice extends Sign
         $this->signedSignatureProperties = $this->domDocument->createElement('xades:SignedSignatureProperties');
         $this->signedProperties->appendChild($this->signedSignatureProperties);
 
-        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now()->format('Y-m-d\TH:i:s.vT:00'));
+        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now('America/Bogota')->format('Y-m-d\TH:i:s.vP'));
         $this->signedSignatureProperties->appendChild($this->signingTime);
 
         $this->signingCertificate = $this->domDocument->createElement('xades:SigningCertificate');

--- a/src/XAdES/SignPayroll.php
+++ b/src/XAdES/SignPayroll.php
@@ -195,7 +195,7 @@ class SignPayroll extends Sign
         $this->signedSignatureProperties = $this->domDocument->createElement('xades:SignedSignatureProperties');
         $this->signedProperties->appendChild($this->signedSignatureProperties);
 
-        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now()->format('Y-m-d\TH:i:s.vT:00'));
+        $this->signingTime = $this->domDocument->createElement('xades:SigningTime', Carbon::now('America/Bogota')->format('Y-m-d\TH:i:s.vP'));
         $this->signedSignatureProperties->appendChild($this->signingTime);
 
         $this->signingCertificate = $this->domDocument->createElement('xades:SigningCertificate');


### PR DESCRIPTION
El formato anterior usaba una notación de zona horaria incorrecta (`UTC:00`), lo que causaba errores de validación. Se actualizó el formato para cumplir con ISO 8601, ahora soportando correctamente UTC (`Z`) o un offset de zona horaria (ej. `-05:00` para America/Bogota).